### PR TITLE
fixing aws provider version

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = "~> 0.12"
 
   required_providers {
-    aws = "~> 2.54"
+    aws = "~> v2.54"
   }
 }


### PR DESCRIPTION
---error message related
No provider "aws" plugins meet the constraint "v2.38.0,~> 2.54".

The version constraint is derived from the "version" argument within the
provider "aws" block in configuration. Child modules may also apply
provider version constraints. To view the provider versions requested by each
module in the current configuration, run "terraform providers".

To proceed, the version constraints for this provider must be relaxed by
either adjusting or removing the "version" argument in the provider blocks
throughout the configuration.